### PR TITLE
fix: Use langchain_core imports and add dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,31 +41,25 @@ dependencies = [
     "pydantic>=2.1.0",
     "python-dotenv>=1.0.0",
     "pydantic-settings",
-    
     # LangChain and related packages
     "langchain>=0.0.267",
     "langchain-openai>=0.0.2",
     "langgraph>=0.0.17",
     "openai>=1.3.0",
-    
     # GraphQL support
     "graphql-core>=3.0.0",
     "gql",
-    
     # Utilities
     "requests>=2.31.0",
     "jinja2>=3.1.2",
     "python-multipart>=0.0.6",
     "termcolor",
     "loguru",
-    
-
-    
     # MCP support
     "fastmcp>=0.1.0",
-    
     # Development utilities
-    "ipykernel>=6.0.0"
+    "ipykernel>=6.0.0",
+    "langchain-core>=1.2.7",
 ]
 
 [project.optional-dependencies]

--- a/src/text_to_graphql_mcp/agent.py
+++ b/src/text_to_graphql_mcp/agent.py
@@ -11,7 +11,7 @@ import re
 
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
-from langchain.prompts import PromptTemplate, ChatPromptTemplate
+from langchain_core.prompts import PromptTemplate, ChatPromptTemplate
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.language_models import BaseChatModel

--- a/src/text_to_graphql_mcp/tools/data_visualization.py
+++ b/src/text_to_graphql_mcp/tools/data_visualization.py
@@ -8,7 +8,7 @@ from typing import Dict, Any, Optional, List
 from collections import Counter
 from ..types import AgentState  
 from ..logger import logger
-from langchain.prompts import ChatPromptTemplate
+from langchain_core.prompts import ChatPromptTemplate
 
 def get_data_visualization_prompt() -> ChatPromptTemplate:
     """


### PR DESCRIPTION
## Summary

- Switch prompt imports from `langchain.prompts` to `langchain_core.prompts` to use the stable API directly
- Add `langchain-core>=1.2.7` as an explicit dependency in `pyproject.toml`
- Clean up blank lines between dependency groups in `pyproject.toml`

## Test plan

- [ ] Verify `from langchain_core.prompts import PromptTemplate, ChatPromptTemplate` resolves correctly
- [ ] Verify agent and data visualization tool work with updated imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)